### PR TITLE
chore(gha): build, test and upload build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+---
+name: Animal Farm NodeJS CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '20.x'
+    - name: Install dependencies 
+      run: npm ci
+    - name: Lint
+      run: npm run lint --if-present
+    - name: Build
+      run: npm run build --if-present
+    - name: Test
+      run: npm test
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist\spa


### PR DESCRIPTION
Closes #2

Add a GHA which builds, tests, and publishes the `dist/spa` folder.